### PR TITLE
Open_timeout stored in Session

### DIFF
--- a/pyvisa-sim/highlevel.py
+++ b/pyvisa-sim/highlevel.py
@@ -114,7 +114,7 @@ class SimVisaLibrary(highlevel.VisaLibraryBase):
         # Loops through all session types, tries to parse the resource name and if ok, open it.
         cls = sessions.Session.get_session_class(parsed.interface_type_const, parsed.resource_class)
 
-        sess = cls(session, resource_name, parsed)
+        sess = cls(session, resource_name, parsed, open_timeout)
 
         try:
             sess.device = self.devices[sess.attrs[constants.VI_ATTR_RSRC_NAME]]

--- a/pyvisa-sim/sessions.py
+++ b/pyvisa-sim/sessions.py
@@ -68,10 +68,11 @@ class Session(object):
             return python_class
         return _internal
 
-    def __init__(self, resource_manager_session, resource_name, parsed=None):
+    def __init__(self, resource_manager_session, resource_name, parsed=None, open_timeout=None):
         if parsed is None:
             parsed = rname.parse_resource_name(resource_name)
         self.parsed = parsed
+        self.open_timeout = open_timeout
         self.attrs = {constants.VI_ATTR_RM_SESSION: resource_manager_session,
                       constants.VI_ATTR_RSRC_NAME: str(parsed),
                       constants.VI_ATTR_RSRC_CLASS: parsed.resource_class,


### PR DESCRIPTION
parameter `open_timeout` is passed to session and stored there. Can be used in derived classes.
_No further processing is done, just interface changes_

It aligns code with the change in pyvisa/pyvisa-py#115 due to requirements in pyvisa/pyvisa-py#88



