### PR TITLE
Fixed NotImplementedError when calling the clear() method

### DIFF
--- a/pyvisa-sim/highlevel.py
+++ b/pyvisa-sim/highlevel.py
@@ -255,3 +255,7 @@ class SimVisaLibrary(highlevel.VisaLibraryBase):
     def discard_events(self, session, event_type, mechanism):
         # TODO: implement this for GPIB finalization
         pass
+
+    def clear(self, session):
+        # Override to prevent the base class from raising a NotImplementedError
+        pass

--- a/pyvisa-sim/testsuite/test_all.py
+++ b/pyvisa-sim/testsuite/test_all.py
@@ -37,6 +37,17 @@ def test_list(resource_manager):
 
 @pytest.mark.parametrize('resource', [
     'ASRL1::INSTR',
+])
+def test_clear(resource, resource_manager):
+    inst = resource_manager.open_resource(resource, read_termination='\n',
+                                          write_termination='\r\n' if resource.startswith('ASRL') else '\n')
+
+    inst.clear()
+    inst.close()
+
+
+@pytest.mark.parametrize('resource', [
+    'ASRL1::INSTR',
     'GPIB0::8::0::INSTR',
     'TCPIP0::localhost::inst0::INSTR',
     'TCPIP0::localhost::10001::SOCKET',


### PR DESCRIPTION
- Added a clear() method to highlevel.py to prevent the NotImplementedError raised by the base class method.
- Added a test function to verify the fix.