### PR TITLE
Testsuite fixes (GPIB secondary addr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyvisa_sim/testsuite/test_all.py
+++ b/pyvisa_sim/testsuite/test_all.py
@@ -24,10 +24,10 @@ def test_list(resource_manager):
         "USB0::0x1111::0x2222::0x3692::0::INSTR",
         "USB0::0x1111::0x2222::0x4444::0::INSTR",
         "USB0::0x1111::0x2222::0x4445::0::RAW",
-        "GPIB0::4::0::INSTR",
-        "GPIB0::8::0::INSTR",
-        "GPIB0::9::0::INSTR",
-        "GPIB0::10::0::INSTR",
+        "GPIB0::4::INSTR",
+        "GPIB0::8::INSTR",
+        "GPIB0::9::INSTR",
+        "GPIB0::10::INSTR",
     }
 
 
@@ -35,7 +35,7 @@ def test_list(resource_manager):
     "resource",
     [
         "ASRL1::INSTR",
-        "GPIB0::8::0::INSTR",
+        "GPIB0::8::INSTR",
         "TCPIP0::localhost::inst0::INSTR",
         "TCPIP0::localhost::10001::SOCKET",
         "USB0::0x1111::0x2222::0x1234::0::INSTR",


### PR DESCRIPTION
Fixes pytest failures in the CI job (pyvisa_sim/testsuite/test_all.py::test_instruments[GPIB0::8::0::INSTR] FAILED):

- Removed secondary GPIB addresses from testsuite to match default.yaml definitions. (due to recent GPIB secondary address change, a secondary address of 0 is no longer equivalent to an omitted secondary address)