### PR TITLE
Fix mypy error in channels.py

### DIFF
--- a/pyvisa_sim/channels.py
+++ b/pyvisa_sim/channels.py
@@ -71,7 +71,6 @@ class Channels(Component):
     can_select: bool
 
     def __init__(self, device: "Device", ids: List[str], can_select: bool):
-
         super(Channels, self).__init__()
         self.can_select: bool = can_select
         self._selected = None

--- a/pyvisa_sim/devices.py
+++ b/pyvisa_sim/devices.py
@@ -122,7 +122,6 @@ class Device(Component):
     delimiter: bytes
 
     def __init__(self, name: str, delimiter: bytes) -> None:
-
         super(Device, self).__init__()
         self.name = name
         self.delimiter = delimiter

--- a/pyvisa_sim/sessions/gpib.py
+++ b/pyvisa_sim/sessions/gpib.py
@@ -15,7 +15,6 @@ from . import session
 
 @session.Session.register(constants.InterfaceType.gpib, "INSTR")
 class GPIBInstrumentSession(session.Session):
-
     parsed: rname.GPIBInstr
 
     def after_parsing(self) -> None:

--- a/pyvisa_sim/sessions/serial.py
+++ b/pyvisa_sim/sessions/serial.py
@@ -16,7 +16,6 @@ from . import session
 
 @session.Session.register(constants.InterfaceType.asrl, "INSTR")
 class SerialInstrumentSession(session.Session):
-
     parsed: rname.ASRLInstr
 
     def after_parsing(self) -> None:
@@ -25,7 +24,6 @@ class SerialInstrumentSession(session.Session):
         )
 
     def read(self, count: int) -> Tuple[bytes, constants.StatusCode]:
-
         # TODO: Implement VI_ATTR_SUPPRESS_END_EN
         end_in, _ = self.get_attribute(constants.ResourceAttribute.asrl_end_in)
 
@@ -56,7 +54,6 @@ class SerialInstrumentSession(session.Session):
                     return out, constants.StatusCode.success_termination_character_read
 
             elif end_in == constants.SerialTermination.last_bit:
-
                 if common.last_int(out) & mask:
                     return out, constants.StatusCode.success
 
@@ -90,7 +87,6 @@ class SerialInstrumentSession(session.Session):
             for val in common.iter_bytes(data, mask, send_end):
                 self.device.write(val)
         else:
-
             for i in range(len(data)):
                 self.device.write(data[i : i + 1])
 

--- a/pyvisa_sim/sessions/tcpip.py
+++ b/pyvisa_sim/sessions/tcpip.py
@@ -59,7 +59,6 @@ class BaseTCPIPSession(session.Session):
 
 @session.Session.register(constants.InterfaceType.tcpip, "INSTR")
 class TCPIPInstrumentSession(BaseTCPIPSession):
-
     parsed: rname.TCPIPInstr
 
     def after_parsing(self) -> None:
@@ -74,7 +73,6 @@ class TCPIPInstrumentSession(BaseTCPIPSession):
 
 @session.Session.register(constants.InterfaceType.tcpip, "SOCKET")
 class TCPIPSocketSession(BaseTCPIPSession):
-
     parsed: rname.TCPIPSocket
 
     def after_parsing(self) -> None:

--- a/pyvisa_sim/sessions/usb.py
+++ b/pyvisa_sim/sessions/usb.py
@@ -75,7 +75,6 @@ class USBInstrumentSession(session.Session):
 
 @session.Session.register(constants.InterfaceType.usb, "RAW")
 class USBRawSession(session.Session):
-
     parsed: rname.USBRaw
 
     def after_parsing(self) -> None:


### PR DESCRIPTION
This _technically_ fixes the mypy error seen in `channels.py`, but I'm not sure if it's the _best_ fix. IMO it simply masks the symptom rather than fixes the root cause. I think more refactoring and architecture changes might be needed to fix the root issue.

```shell
$ mypy pyvisa_sim/
pyvisa_sim/channels.py:199: error: Argument 1 to "set_value" of "Property" has incompatible type "Union[Any, Dict[Any, Any]]"; expected "str"  [arg-type]
```

I also move the type hints to `component.Component.__init__` as that's common practice.

One of the issues is that the `stringparser` library doesn't have type annotations, so mypy sets `parser` to `Any` here:

https://github.com/pyvisa/pyvisa-sim/blob/b0c22826ad506cc5c5acc155bdca3764dfe14f5e/pyvisa_sim/channels.py#L187

and then `parsed` to `Any` here:

https://github.com/pyvisa/pyvisa-sim/blob/b0c22826ad506cc5c5acc155bdca3764dfe14f5e/pyvisa_sim/channels.py#L189

From there, the `isinstance` statement end up doing type narrowing to `Dict[Any, Any]` which then gets `Union`'d with `Any` from before. 

The issue is that the `self.set_value` function doesn't accept `Any`. Based on my (possibly flawed) understanding of the code, it looks like it's safe enough to just convert to a string before calling `set_value`. So that's what I do.

In addition, I ran a temporary backport of this change to v0.5.1 and ran my tests for a separate project that uses `pyvisa-sim`, and those still ran OK so... I guess it's OK?