### PR TITLE
Fix support for dialogs without response

### DIFF
--- a/pyvisa_sim/channels.py
+++ b/pyvisa_sim/channels.py
@@ -196,7 +196,7 @@ class Channels(Component):
                     self._selected = parsed["ch_id"]
                     self._properties[name].set_value(parsed["0"])
                 else:
-                    self._properties[name].set_value(parsed)
+                    self._properties[name].set_value(parsed)  # type: ignore[arg-type]
                 return response
             except ValueError:
                 if isinstance(error_response, bytes):

--- a/pyvisa_sim/parser.py
+++ b/pyvisa_sim/parser.py
@@ -63,7 +63,7 @@ class SimpleChainmap(Generic[K, V]):
 
 def _get_pair(dd: Dict[str, str]) -> Tuple[str, str]:
     """Return a pair from a dialogue dictionary."""
-    return dd["q"].strip(" "), dd["r"].strip(" ")
+    return dd["q"].strip(" "), dd["r"].strip(" ") if "r" in dd else NoResponse
 
 
 def _get_triplet(

--- a/pyvisa_sim/parser.py
+++ b/pyvisa_sim/parser.py
@@ -63,7 +63,7 @@ class SimpleChainmap(Generic[K, V]):
 
 def _get_pair(dd: Dict[str, str]) -> Tuple[str, str]:
     """Return a pair from a dialogue dictionary."""
-    return dd["q"].strip(" "), dd["r"].strip(" ") if "r" in dd else NoResponse
+    return dd["q"].strip(" "), dd["r"].strip(" ") if "r" in dd else NoResponse  # type: ignore[return-value]
 
 
 def _get_triplet(

--- a/pyvisa_sim/testsuite/test_parser.py
+++ b/pyvisa_sim/testsuite/test_parser.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from typing import Dict, Tuple
+
+import pytest
+
+from pyvisa_sim import parser
+from pyvisa_sim.component import NoResponse, OptionalStr
+
+
+@pytest.mark.parametrize(
+    "dialogue_dict, want",
+    [
+        ({"q": "foo", "r": "bar"}, ("foo", "bar")),
+        ({"q": "foo ", "r": " bar"}, ("foo", "bar")),
+        ({"q": " foo", "r": "bar "}, ("foo", "bar")),
+        ({"q": " foo ", "r": " bar "}, ("foo", "bar")),
+        # Make sure to support queries that don't have responses
+        ({"q": "foo"}, ("foo", NoResponse)),
+        # Ignore other keys
+        ({"q": "foo", "bar": "bar"}, ("foo", NoResponse)),
+    ],
+)
+def test_get_pair(dialogue_dict: Dict[str, str], want: Tuple[str, OptionalStr]) -> None:
+    got = parser._get_pair(dialogue_dict)
+    assert got == want
+
+
+def test_get_pair_requires_query_key() -> None:
+    with pytest.raises(KeyError):
+        parser._get_pair({"r": "bar"})
+
+
+@pytest.mark.parametrize(
+    "dialogue_dict, want",
+    [
+        ({"q": "foo", "r": "bar", "e": "baz"}, ("foo", "bar", "baz")),
+        ({"q": "foo ", "r": " bar", "e": " baz "}, ("foo", "bar", "baz")),
+        ({"q": " foo", "r": "bar ", "e": "baz "}, ("foo", "bar", "baz")),
+        ({"q": " foo ", "r": " bar ", "e": " baz"}, ("foo", "bar", "baz")),
+        # Make sure to support queries that don't have responses
+        ({"q": "foo"}, ("foo", NoResponse, NoResponse)),
+        ({"q": "foo", "r": "bar"}, ("foo", "bar", NoResponse)),
+        ({"q": "foo", "e": "bar"}, ("foo", NoResponse, "bar")),
+        # Ignore other keys
+        ({"q": "foo", "bar": "bar"}, ("foo", NoResponse, NoResponse)),
+    ],
+)
+def test_get_triplet(
+    dialogue_dict: Dict[str, str], want: Tuple[str, OptionalStr, OptionalStr]
+) -> None:
+    got = parser._get_triplet(dialogue_dict)
+    assert got == want
+
+
+def test_get_triplet_requires_query_key() -> None:
+    with pytest.raises(KeyError):
+        parser._get_triplet({"r": "bar"})


### PR DESCRIPTION
Fixes #76.

Re-add support for missing "response" key in the `dialogues` part and add tests for `_get_pair` and `_get_triplet` so that a similar regression won't happen in the future.

Note: Fully fixing the type annotations ended up being a much larger endeavor than expected, so I left that out of this PR and simply used `type: ignore`.