### PR TITLE
Fix `common.iter_bytes`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 
 - Fixed debug logging a single character at a time. PR #79
+- Fixed issue with `common.iter_bytes` where the masked bits would be incorrect.
+  PR #81
 
 0.5.1 (2022-09-08)
 ------------------

--- a/pyvisa_sim/common.py
+++ b/pyvisa_sim/common.py
@@ -23,7 +23,7 @@ def _create_bitmask(bits: int) -> int:
 
 
 def iter_bytes(
-    data: bytes, data_bits: Optional[int] = None, send_end: Optional[bool] = False
+    data: bytes, data_bits: Optional[int] = None, send_end: Optional[bool] = None
 ) -> Iterator[bytes]:
     """Clip values to the correct number of bits per byte.
 
@@ -37,7 +37,7 @@ def iter_bytes(
         Acceptable range is 5 to 8, inclusive. Values above 8 will be clipped to 8.
         This maps to the VISA attribute VI_ATTR_ASRL_DATA_BITS.
     send_end :
-        If None, apply the mask that is determined by data_bits.
+        If None (the default), apply the mask that is determined by data_bits.
         If False, apply the mask and set the highest (post-mask) bit to 0 for
         all bytes.
         If True, apply the mask and set the highest (post-mask) bit to 0 for

--- a/pyvisa_sim/common.py
+++ b/pyvisa_sim/common.py
@@ -45,6 +45,7 @@ def iter_bytes(
     + https://www.ivifoundation.org/downloads/Architecture%20Specifications/vpp43_2022-05-19.pdf,
     + https://www.ni.com/docs/en-US/bundle/ni-visa/page/ni-visa/vi_attr_asrl_data_bits.html,
     + https://www.ni.com/docs/en-US/bundle/ni-visa/page/ni-visa/vi_attr_asrl_end_out.html
+
     """
     if send_end and data_bits is None:
         raise ValueError("'send_end' requires a valid 'data_bits' value.")

--- a/pyvisa_sim/common.py
+++ b/pyvisa_sim/common.py
@@ -9,29 +9,51 @@ Do not edit here.
 
 """
 import logging
-from typing import Callable, Optional, Sequence
+from typing import Callable, Iterator, Optional, Sequence
 
 from pyvisa import logger
 
 logger = logging.LoggerAdapter(logger, {"backend": "sim"})  # type: ignore
 
 
-def iter_bytes(data: bytes, mask: Optional[int] = None, send_end: bool = False):
-    if send_end and mask is None:
-        raise ValueError("send_end requires a valid mask.")
+def iter_bytes(
+    data: bytes, data_bits: Optional[int] = None, send_end: bool = False
+) -> Iterator[bytes]:
+    """Clip values to the correct number of bits per byte.
 
-    if mask is None:
+    Serial communication may use from 5 to 8 bits.
+
+    Parameters
+    ----------
+    data : The data to clip as a byte string.
+    data_bits : How many bits per byte should be sent. Clip to this many bits.
+        For example: data_bits=5: 0xff (0b1111_1111) --> 0x1f (0b0001_1111)
+    send_end : If True, send the final byte unclipped (with all 8 bits).
+
+    References
+    ----------
+    + https://www.ivifoundation.org/downloads/Architecture%20Specifications/vpp43_2022-05-19.pdf,
+    + https://www.ni.com/docs/en-US/bundle/ni-visa/page/ni-visa/vi_attr_asrl_data_bits.html,
+    + https://www.ni.com/docs/en-US/bundle/ni-visa/page/ni-visa/vi_attr_asrl_end_out.html
+    """
+    if send_end and data_bits is None:
+        raise ValueError("'send_end' requires a valid 'data_bits' value.")
+
+    if data_bits is None:
         for d in data:
             yield bytes([d])
-
     else:
+        # 2**8     = 0b1000_0000
+        # 2**8 - 1 = 0b0111_1111
+        mask = 2**data_bits - 1
+
         for d in data[:-1]:
-            yield bytes([d & ~mask])
+            yield bytes([d & mask])
 
         if send_end:
-            yield bytes([data[-1] | ~mask])
+            yield bytes([data[-1]])
         else:
-            yield bytes([data[-1] & ~mask])
+            yield bytes([data[-1] & mask])
 
 
 int_to_byte: Callable[[int], bytes] = lambda val: bytes([val])

--- a/pyvisa_sim/sessions/serial.py
+++ b/pyvisa_sim/sessions/serial.py
@@ -82,9 +82,10 @@ class SerialInstrumentSession(session.MessageBasedSession):
         len_transferred = len(data)
 
         if asrl_end == constants.SerialTermination.last_bit:
-            last_bit, _ = self.get_attribute(constants.ResourceAttribute.asrl_data_bits)
-            mask = 1 << (last_bit - 1)
-            val = b"".join(common.iter_bytes(data, mask, send_end))
+            data_bits, _ = self.get_attribute(
+                constants.ResourceAttribute.asrl_data_bits
+            )
+            val = b"".join(common.iter_bytes(data, data_bits, send_end))
             self.device.write(val)
         else:
             self.device.write(data)

--- a/pyvisa_sim/sessions/serial.py
+++ b/pyvisa_sim/sessions/serial.py
@@ -75,6 +75,7 @@ class SerialInstrumentSession(session.MessageBasedSession):
     def write(self, data: bytes) -> Tuple[int, constants.StatusCode]:
         send_end, _ = self.get_attribute(constants.ResourceAttribute.send_end_enabled)
         asrl_end, _ = self.get_attribute(constants.ResourceAttribute.asrl_end_out)
+        data_bits, _ = self.get_attribute(constants.ResourceAttribute.asrl_data_bits)
 
         end_char, _ = self.get_attribute(constants.ResourceAttribute.termchar)
         end_char = common.int_to_byte(end_char)
@@ -82,13 +83,11 @@ class SerialInstrumentSession(session.MessageBasedSession):
         len_transferred = len(data)
 
         if asrl_end == constants.SerialTermination.last_bit:
-            data_bits, _ = self.get_attribute(
-                constants.ResourceAttribute.asrl_data_bits
-            )
             val = b"".join(common.iter_bytes(data, data_bits, send_end))
             self.device.write(val)
         else:
-            self.device.write(data)
+            val = b"".join(common.iter_bytes(data, data_bits, send_end=None))
+            self.device.write(val)
 
             if asrl_end == constants.SerialTermination.termination_char:
                 if send_end:

--- a/pyvisa_sim/testsuite/test_common.py
+++ b/pyvisa_sim/testsuite/test_common.py
@@ -6,35 +6,34 @@ from pyvisa_sim import common
 
 
 @pytest.mark.parametrize(
-    "data, mask, send_end, want",
+    "data, data_bits, send_end, want",
     [
-        (b"1234", None, False, b"1234"),
-        (b"41234", 3, False, b"40004"),
-        # Can't figure this one out. Getting ValueError: bytes must in in range(0, 256)
-        # If I knew more about the purpose of `iter_bytes` then maybe I could
-        # reconcile it, but I don't have time to investigate right now.
-        pytest.param(
-            b"1234",
-            3,
-            True,
-            b"1234",
-            marks=pytest.mark.xfail(
-                reason=(
-                    "ValueError bytes must be in range(0, 256). TODO: figure"
-                    " out correct 'want' value."
-                )
-            ),
-        ),
+        (b"\x01", None, False, b"\x01"),
+        (b"hello world!", None, False, b"hello world!"),
+        # Ensure clipping works as expected
+        (b"\x04", 2, False, b"\x00"),  # 0b0100 --> 0b0000
+        (b"\x04", 2, True, b"\x04"),  # 0b0100 --> 0b0100
+        (b"\x05", 2, False, b"\x01"),  # 0b0101 --> 0b0001
+        (b"\xff", 7, False, b"\x7f"),  # 0b1111_1111 --> 0b0111_1111
+        (b"\xff", 7, True, b"\xff"),  # 0b1111_1111 --> 0b1111_1111
+        # Clipping with 8 or more bits does nothing, as `data` is bytes
+        # which is limited to 8 bits per character.
+        (b"\xff", 8, False, b"\xff"),
+        (b"\xff", 9, False, b"\xff"),
+        # Make sure we're iterating correctly
+        (b"\x6d\x5c\x25", 4, False, b"\r\x0c\x05"),
+        (b"\x6d\x5c\x25", 4, True, b"\r\x0c\x25"),
+        (b"`\xa0", 6, False, b"  "),
     ],
 )
 def test_iter_bytes(
-    data: bytes, mask: Optional[int], send_end: bool, want: List[bytes]
+    data: bytes, data_bits: Optional[int], send_end: bool, want: List[bytes]
 ) -> None:
-    got = b"".join(common.iter_bytes(data, mask=mask, send_end=send_end))
+    got = b"".join(common.iter_bytes(data, data_bits=data_bits, send_end=send_end))
     assert got == want
 
 
-def test_iter_bytes_with_send_end_requires_mask() -> None:
+def test_iter_bytes_with_send_end_requires_data_bits() -> None:
     with pytest.raises(ValueError):
         # Need to wrap in list otherwise the iterator is never called.
-        list(common.iter_bytes(b"", mask=None, send_end=True))
+        list(common.iter_bytes(b"", data_bits=None, send_end=True))

--- a/pyvisa_sim/testsuite/test_common.py
+++ b/pyvisa_sim/testsuite/test_common.py
@@ -6,24 +6,57 @@ from pyvisa_sim import common
 
 
 @pytest.mark.parametrize(
+    "bits, want",
+    [
+        (0, 0b0),
+        (1, 0b1),
+        (5, 0b0001_1111),
+        (7, 0b0111_1111),
+        (8, 0b1111_1111),
+        (11, 0b0111_1111_1111),
+    ],
+)
+def test_create_bitmask(bits, want):
+    got = common._create_bitmask(bits)
+    assert got == want
+
+
+@pytest.mark.parametrize(
     "data, data_bits, send_end, want",
     [
         (b"\x01", None, False, b"\x01"),
         (b"hello world!", None, False, b"hello world!"),
-        # Ensure clipping works as expected
-        (b"\x04", 2, False, b"\x00"),  # 0b0100 --> 0b0000
-        (b"\x04", 2, True, b"\x04"),  # 0b0100 --> 0b0100
-        (b"\x05", 2, False, b"\x01"),  # 0b0101 --> 0b0001
-        (b"\xff", 7, False, b"\x7f"),  # 0b1111_1111 --> 0b0111_1111
-        (b"\xff", 7, True, b"\xff"),  # 0b1111_1111 --> 0b1111_1111
-        # Clipping with 8 or more bits does nothing, as `data` is bytes
-        # which is limited to 8 bits per character.
-        (b"\xff", 8, False, b"\xff"),
-        (b"\xff", 9, False, b"\xff"),
-        # Make sure we're iterating correctly
-        (b"\x6d\x5c\x25", 4, False, b"\r\x0c\x05"),
-        (b"\x6d\x5c\x25", 4, True, b"\r\x0c\x25"),
-        (b"`\xa0", 6, False, b"  "),
+        # Only apply the mask
+        (b"\x03", 2, None, b"\x03"),  # 0b0000_0011 --> 0b0000_0011
+        (b"\x04", 2, None, b"\x00"),  # 0b0000_0100 --> 0b0000_0000
+        (b"\xff", 5, None, b"\x1f"),  # 0b1111_1111 --> 0b0001_1111
+        (b"\xfe", 7, None, b"\x7e"),  # 0b1111_1110 --> 0b0111_1110
+        (b"\xfe", 8, None, b"\xfe"),  # 0b1111_1110 --> 0b1111_1110
+        (b"\xff", 9, None, b"\xff"),  # 0b1111_1111 --> 0b1111_1111
+        # Always set highest bit *of data_bits* to 0
+        (b"\x04", 2, False, b"\x00"),  # 0b0000_0100 --> 0b0000_0000
+        (b"\x04", 3, False, b"\x00"),  # 0b0000_0100 --> 0b0000_0000
+        (b"\x05", 3, False, b"\x01"),  # 0b0000_0101 --> 0b0000_0001
+        (b"\xff", 7, False, b"\x3f"),  # 0b1111_1111 --> 0b0011_1111
+        (b"\xff", 8, False, b"\x7f"),  # 0b1111_1111 --> 0b0111_1111
+        # Always set highest bit *of data_bits* to 1
+        (b"\x04", 2, True, b"\x02"),  # 0b0000_0100 --> 0b0000_0010
+        (b"\x04", 3, True, b"\x04"),  # 0b0000_0100 --> 0b0000_0100
+        (b"\x01", 3, True, b"\x05"),  # 0b0000_0001 --> 0b0000_0101
+        (b"\x9f", 7, True, b"\x5f"),  # 0b1001_1111 --> 0b0101_1111
+        (b"\x9f", 8, True, b"\x9f"),  # 0b1001_1111 --> 0b1001_1111
+        # data_bits >8 bits act like data_bits=8, as type(data) is "bytes"
+        # which is limited 8 bits per character.
+        (b"\xff", 9, None, b"\xff"),
+        (b"\xff", 9, False, b"\x7f"),
+        (b"\xff", 9, True, b"\xff"),
+        # send_end should only impact the final byte
+        (b"\x6d\x5c\x25\x25", 4, None, b"\r\x0c\x05\x05"),
+        (b"\x6d\x5c\x25\x25", 4, False, b"\r\x0c\x05\x05"),
+        (b"\x6d\x5c\x25\x25", 4, True, b"\r\x0c\x05\x0d"),
+        (b"`\xa0", 6, None, b"  "),
+        (b"`\xa0", 6, False, b" \x00"),
+        (b"`\xa0", 6, True, b"  "),
     ],
 )
 def test_iter_bytes(
@@ -37,3 +70,8 @@ def test_iter_bytes_with_send_end_requires_data_bits() -> None:
     with pytest.raises(ValueError):
         # Need to wrap in list otherwise the iterator is never called.
         list(common.iter_bytes(b"", data_bits=None, send_end=True))
+
+
+def test_iter_bytes_raises_on_bad_data_bits() -> None:
+    with pytest.raises(ValueError):
+        list(common.iter_bytes(b"", data_bits=0, send_end=None))

--- a/pyvisa_sim/testsuite/test_serial.py
+++ b/pyvisa_sim/testsuite/test_serial.py
@@ -21,7 +21,7 @@ def test_serial_write_with_termination_last_bit(resource_manager):
 
     instr.set_visa_attribute(
         pyvisa.constants.ResourceAttribute.send_end_enabled,
-        pyvisa.constants.VI_TRUE,
+        pyvisa.constants.VI_FALSE,
     )
 
     instr.write("*IDN?")

--- a/pyvisa_sim/testsuite/test_serial.py
+++ b/pyvisa_sim/testsuite/test_serial.py
@@ -19,10 +19,9 @@ def test_serial_write_with_termination_last_bit(resource_manager):
         pyvisa.constants.SerialTermination.last_bit,
     )
 
-    # There's a bug (maybe?) in common.iter_bytes that we want to avoid for now.
     instr.set_visa_attribute(
         pyvisa.constants.ResourceAttribute.send_end_enabled,
-        pyvisa.constants.VI_FALSE,
+        pyvisa.constants.VI_TRUE,
     )
 
     instr.write("*IDN?")


### PR DESCRIPTION
Fixes #80.

See that Issue for more detail.

+ Adjust `iter_bytes` function signature to use `data_bits` instead of `mask`. Calculate the mask base on those number of bits.
+ Update docstring
+ Update tests