### PR TITLE
Use the monotonic clock to measure time elapsed

### DIFF
--- a/pyvisa_sim/sessions/serial.py
+++ b/pyvisa_sim/sessions/serial.py
@@ -36,11 +36,11 @@ class SerialInstrumentSession(session.MessageBasedSession):
 
         last_bit, _ = self.get_attribute(constants.ResourceAttribute.asrl_data_bits)
         mask = 1 << (last_bit - 1)
-        start = time.time()
+        start = time.monotonic()
 
         out = b""
 
-        while time.time() - start <= timeout:
+        while time.monotonic() - start <= timeout:
             last = self.device.read()
 
             if not last:

--- a/pyvisa_sim/sessions/session.py
+++ b/pyvisa_sim/sessions/session.py
@@ -214,11 +214,11 @@ class MessageBasedSession(Session):
         timeout, _ = self.get_attribute(constants.ResourceAttribute.timeout_value)
         timeout /= 1000
 
-        start = time.time()
+        start = time.monotonic()
 
         out = b""
 
-        while time.time() - start <= timeout:
+        while time.monotonic() - start <= timeout:
             last = self.device.read()
 
             if not last:


### PR DESCRIPTION
For measuring elapsed time, one should use a monotonic clock instead of the system clock because the system clock can go backwards in time, whereas a monotonic clock is guaranteed to be non-decreasing.