### PR TITLE
Fix `SimVisaLibrary.read` violating `viRead` success code specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 PyVISA-sim Changelog
 ====================
 
+Unreleased
+----------
+- Fixed `SimVisaLibrary.read` violating the `viRead` specification in various ways. This
+  fixed issue #45 and other bugs. PR #98
+
 0.6.0 (2023-11-27)
 ------------------
 

--- a/pyvisa_sim/common.py
+++ b/pyvisa_sim/common.py
@@ -10,7 +10,7 @@ Do not edit here.
 """
 
 import logging
-from typing import Iterator, Optional, Sequence
+from typing import Iterator, Optional
 
 from pyvisa import logger
 
@@ -90,7 +90,3 @@ def iter_bytes(
 
 def int_to_byte(val: int) -> bytes:
     return bytes([val])
-
-
-def last_int(val: Sequence[int]) -> int:
-    return val[-1]

--- a/pyvisa_sim/sessions/session.py
+++ b/pyvisa_sim/sessions/session.py
@@ -271,7 +271,9 @@ class MessageBasedSession(Session):
                 # Rule 6.1.3.
                 return out, constants.StatusCode.success_max_count_read
 
-            time.sleep(0.01)
+            # Busy-wait only if the device's output buffer was empty.
+            if not last:
+                time.sleep(0.01)
         else:
             return out, constants.StatusCode.error_timeout
 

--- a/pyvisa_sim/testsuite/test_all.py
+++ b/pyvisa_sim/testsuite/test_all.py
@@ -84,6 +84,9 @@ def test_instruments(resource, resource_manager):
 
     assert_instrument_response(inst, "!CAL", "OK")
 
+    with inst.read_termination_context(""):
+        assert_instrument_response(inst, "?IDN", "LSG Serial #1234\n")
+
     # Errors
 
     assert_instrument_response(inst, "!WVF 23", "ERROR")


### PR DESCRIPTION
hi! this fixes #45.

i believe this implementation is spec. compliant, with one possible exception: there's a case that the spec. doesn't seem to state what should happen in.

Rule 6.1.7 states that when using ASRL with `VI_ATTR_ASRL_END_IN = VI_ASRL_END_TERMCHAR`, when a termination character is read it should get treated as having an END indicator.

as far as I can tell, however, the spec. does not state what should happen when using ASRL with `VI_ATTR_ASRL_END_IN = VI_ASRL_END_LAST_BIT` and a character arrives with the matching bit set. should it get treated as END or should it get treated as a termination character? the status code depends on which it gets treated as.

since the only three cases for `VI_ATTR_ASRL_END_IN` are `VI_ASRL_END_NONE` (uninteresting), `VI_ASRL_END_TERMCHAR`, and `VI_ASRL_END_LAST_BIT` and since Rule 6.1.7 explicitly states that `VI_ASRL_END_TERMCHAR` causes the character to get treated as having an END indicator, not as a termination character, it seemed to me that it is more more appropriate for `VI_ASRL_END_LAST_BIT` to also cause the character to get treated as having an END.

either way, this fixes #45 though.