### PR TITLE
Avoid quadratic bytes concatenation in `SimVisaLibrary.read`

### DIFF
--- a/pyvisa_sim/sessions/session.py
+++ b/pyvisa_sim/sessions/session.py
@@ -234,7 +234,7 @@ class MessageBasedSession(Session):
 
         start = time.monotonic()
 
-        out = b""
+        out = bytearray()
 
         while time.monotonic() - start <= timeout:
             last, end_indicator = self.device.read()


### PR DESCRIPTION
Very minor thing I noticed while doing #98 in March. Benchmarking against the test suite, the performance impact seems to be statistically negligible because the strings there are short.