### PR TITLE
Avoid busy-waiting in `SimVisaLibrary.read`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "PyVISA-sim"
 description = "Simulated backend for PyVISA implementing TCPIP, GPIB, RS232, and USB resources"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE.txt"}
 authors = [
   {name = "Hernan E. Grecco", email = "hernan.grecco@gmail.com"},

--- a/pyvisa_sim/sessions/session.py
+++ b/pyvisa_sim/sessions/session.py
@@ -236,8 +236,8 @@ class MessageBasedSession(Session):
 
         out = bytearray()
 
-        while time.monotonic() - start <= timeout:
-            last, end_indicator = self.device.read()
+        while (timeout_remaining := (timeout - (time.monotonic() - start))) >= 0:
+            last, end_indicator = self.device.read(timeout=timeout_remaining)
 
             out += last
 
@@ -270,10 +270,6 @@ class MessageBasedSession(Session):
             elif len(out) == count:
                 # Rule 6.1.3.
                 return out, constants.StatusCode.success_max_count_read
-
-            # Busy-wait only if the device's output buffer was empty.
-            if not last:
-                time.sleep(0.01)
         else:
             return out, constants.StatusCode.error_timeout
 


### PR DESCRIPTION
This was the patchset I mentioned at https://github.com/pyvisa/pyvisa-sim/pull/98#discussion_r1722768570. (At the time I wrote it, I thought it was necessary for performance, but you caught my mistake there in review.)

I'm posting this still in case you are interested in avoiding busy-waiting here, but I should note that (a) using the (whole) test suite as a benchmark, this change isn't statistically significant and (b) this makes the code slightly more complicated.

Anyway, up to you. Thanks for your time with the bugfix earlier :)