### PR TITLE
Make bytes_in_buffer and flush() work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 PyVISA-sim Changelog
 ====================
 
+Unreleased
+----------
+
+- add support for pyvisa.SerialInstrument.bytes_in_buffer() PR #219
+- add partial support for `viFlush` in `SimVisaLibrary.flush()` PR #219
+
 0.7.1 (04-09-2025)
 ------------------
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,6 @@ ruff
 mypy
 types-PyYAML
 pytest
+pytest-dependency
 sphinx
 sphinx-rtd-theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,5 @@ ruff
 mypy
 types-PyYAML
 pytest
-pytest-dependency
 sphinx
 sphinx-rtd-theme

--- a/pyvisa_sim/highlevel.py
+++ b/pyvisa_sim/highlevel.py
@@ -365,3 +365,37 @@ class SimVisaLibrary(highlevel.VisaLibraryBase):
     def discard_events(self, session, event_type, mechanism):
         # TODO: implement this for GPIB finalization
         pass
+
+    def flush(self, session: VISASession, mask: constants.BufferOperation):
+        try:
+            sess = self.sessions[session]
+        except KeyError:
+            return 0, constants.StatusCode.error_invalid_object
+
+        if mask == constants.BufferOperation.discard_read_buffer:
+            # TODO END indicator
+            raise NotImplementedError("try discard_read_buffer_no_io instead")
+
+        elif mask in {
+            constants.BufferOperation.discard_read_buffer_no_io,
+            constants.BufferOperation.discard_receive_buffer,
+            constants.BufferOperation.discard_receive_buffer2,
+        }:
+            sess.device._output_buffers.clear()
+
+        elif mask in {
+            constants.BufferOperation.discard_write_buffer,
+            constants.BufferOperation.discard_transmit_buffer,
+        }:
+            del sess.device._input_buffer[0:]
+
+        elif mask in {
+            constants.BufferOperation.flush_write_buffer,
+            constants.BufferOperation.flush_transmit_buffer,
+        }:
+            sess.device.write(bytes(sess.device._input_buffer))
+
+        else:
+            raise ValueError(f"unrecognized buffer operation {mask}")
+
+        return constants.StatusCode.success

--- a/pyvisa_sim/highlevel.py
+++ b/pyvisa_sim/highlevel.py
@@ -372,28 +372,34 @@ class SimVisaLibrary(highlevel.VisaLibraryBase):
         except KeyError:
             return 0, constants.StatusCode.error_invalid_object
 
-        if mask == constants.BufferOperation.discard_read_buffer:
-            # TODO END indicator
-            raise NotImplementedError("try discard_read_buffer_no_io instead")
-
-        elif mask in {
-            constants.BufferOperation.discard_read_buffer_no_io,
+        if mask in {
             constants.BufferOperation.discard_receive_buffer,
             constants.BufferOperation.discard_receive_buffer2,
         }:
+            # different from VISA's definition of receive buffer! rather than
+            # being a serial I/O buffer on a host computer, PyVISA-sim's
+            # receive buffer is the *device*'s output buffer.
             sess.device._output_buffers.clear()
 
-        elif mask in {
-            constants.BufferOperation.discard_write_buffer,
-            constants.BufferOperation.discard_transmit_buffer,
-        }:
-            del sess.device._input_buffer[0:]
+        elif mask == constants.BufferOperation.discard_transmit_buffer:
+            # see previous comment. transmit buffer is the *device*'s input
+            # buffer
+            sess.device._input_buffer = bytearray()
+
+        elif mask == constants.BufferOperation.flush_transmit_buffer:
+            # see previous comments. cannot flush the transmit buffer because
+            # it *is* the input buffer of the device itself.
+            pass
 
         elif mask in {
+            constants.BufferOperation.discard_read_buffer,
+            constants.BufferOperation.discard_read_buffer_no_io,
+            constants.BufferOperation.discard_write_buffer,
             constants.BufferOperation.flush_write_buffer,
-            constants.BufferOperation.flush_transmit_buffer,
         }:
-            sess.device.write(bytes(sess.device._input_buffer))
+            raise NotImplementedError(
+                "PyVISA-sim does not implement VISA formatted I/O buffers. Use the low-level I/O buffers instead (e.g. discard_receive_buffer)."
+            )
 
         else:
             raise ValueError(f"unrecognized buffer operation {mask}")

--- a/pyvisa_sim/sessions/serial.py
+++ b/pyvisa_sim/sessions/serial.py
@@ -6,9 +6,9 @@
 
 """
 
-from typing import Tuple
+from typing import Any, Tuple
 
-from pyvisa import constants, rname
+from pyvisa import attributes, constants, rname
 
 from .. import common
 from . import session
@@ -17,6 +17,24 @@ from . import session
 @session.Session.register(constants.InterfaceType.asrl, "INSTR")
 class SerialInstrumentSession(session.MessageBasedSession):
     parsed: rname.ASRLInstr
+
+    def get_attribute(
+        self, attribute: constants.ResourceAttribute
+    ) -> Tuple[Any, constants.StatusCode]:
+        if attribute == constants.ResourceAttribute.asrl_avalaible_number:
+            try:
+                attr = attributes.AttributesByID[attribute]
+            except KeyError:
+                return 0, constants.StatusCode.error_nonsupported_attribute
+
+            if not attr.in_resource(self.session_type):
+                return 0, constants.StatusCode.error_nonsupported_attribute
+
+            return (
+                sum(map(len, self.device._output_buffers)),
+                constants.StatusCode.success,
+            )
+        return super().get_attribute(attribute)
 
     def after_parsing(self) -> None:
         self.attrs[constants.ResourceAttribute.interface_number] = int(

--- a/pyvisa_sim/testsuite/test_all.py
+++ b/pyvisa_sim/testsuite/test_all.py
@@ -4,6 +4,7 @@ import random
 
 import pytest
 
+import pyvisa.constants as constants
 from pyvisa.errors import VisaIOError
 
 # We must fix the seed in order to have reproducible random numbers when
@@ -41,6 +42,52 @@ def test_list(resource_manager):
         "GPIB0::9::INSTR",
         "GPIB0::10::INSTR",
     }
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [
+        "ASRL1::INSTR",
+        "GPIB0::8::INSTR",
+        "TCPIP0::localhost::inst0::INSTR",
+        "TCPIP0::localhost::10001::SOCKET",
+        "USB0::0x1111::0x2222::0x1234::0::INSTR",
+        "USB0::0x1111::0x2222::0x4445::0::RAW",
+    ],
+)
+def test_flush_buffer(resource, resource_manager):
+    inst = resource_manager.open_resource(
+        resource,
+        read_termination="\n",
+        write_termination="\r\n" if resource.startswith("ASRL") else "\n",
+    )
+    visa_library = inst.visalib
+    session_handle = inst.session
+    session = visa_library.sessions[session_handle]
+
+    with pytest.raises(ValueError):
+        inst.flush(constants.BufferOperation.discard_receive_buffer + 1)
+
+    with pytest.raises(NotImplementedError):
+        inst.flush(constants.BufferOperation.discard_read_buffer)
+    with pytest.raises(NotImplementedError):
+        inst.flush(constants.BufferOperation.discard_read_buffer_no_io)
+    with pytest.raises(NotImplementedError):
+        inst.flush(constants.BufferOperation.discard_write_buffer)
+    with pytest.raises(NotImplementedError):
+        inst.flush(constants.BufferOperation.flush_write_buffer)
+
+    session.device._input_buffer = bytearray(b"qwerty")
+    inst.flush(constants.BufferOperation.discard_transmit_buffer)
+    assert session.device._input_buffer == bytearray()
+
+    session.device._output_buffer = bytearray(b"qwerty")
+    inst.flush(constants.BufferOperation.discard_receive_buffer)
+    assert session.device._input_buffer == bytearray()
+
+    session.device._output_buffer = bytearray(b"qwerty")
+    inst.flush(constants.BufferOperation.discard_receive_buffer2)
+    assert session.device._input_buffer == bytearray()
 
 
 @pytest.mark.parametrize(

--- a/pyvisa_sim/testsuite/test_serial.py
+++ b/pyvisa_sim/testsuite/test_serial.py
@@ -1,17 +1,34 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 import pyvisa
+import pyvisa.constants
 from pyvisa_sim.sessions import serial
 
 serial.SerialInstrumentSession
 
 
+@pytest.mark.dependency()
+def test_serial_flush(resource_manager):
+    instr = resource_manager.open_resource(
+        "ASRL4::INSTR",
+        read_termination="\n",
+        write_termination="\r\n",
+    )
+    instr.write("*IDN?")
+    assert instr.bytes_in_buffer != 0
+
+    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)
+    assert instr.bytes_in_buffer == 0
+
+
+@pytest.mark.dependency(depends=["test_serial_flush"])
 def test_serial_write_with_termination_last_bit(resource_manager):
     instr = resource_manager.open_resource(
         "ASRL4::INSTR",
         read_termination="\n",
         write_termination="\r\n",
     )
-
     # Ensure that we test the `asrl_end` block of serial.SerialInstrumentSession.write
     instr.set_visa_attribute(
         pyvisa.constants.ResourceAttribute.asrl_end_out,
@@ -25,3 +42,19 @@ def test_serial_write_with_termination_last_bit(resource_manager):
 
     instr.write("*IDN?")
     assert instr.read() == "SCPI,MOCK,VERSION_1.0"
+
+    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)
+
+
+@pytest.mark.dependency(depends=["test_serial_flush"])
+def test_serial_bytes_in_buffer(resource_manager):
+    instr = resource_manager.open_resource(
+        "ASRL4::INSTR",
+        read_termination="\n",
+        write_termination="\r\n",
+    )
+    instr.write("*IDN?")
+    instr.write(":VOLT:IMM:AMPL?")
+    assert instr.bytes_in_buffer == len(f"SCPI,MOCK,VERSION_1.0\n{1.0:+.8E}\n")
+
+    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)

--- a/pyvisa_sim/testsuite/test_serial.py
+++ b/pyvisa_sim/testsuite/test_serial.py
@@ -1,34 +1,92 @@
 # -*- coding: utf-8 -*-
-import pytest
+import collections
 
 import pyvisa
+import pyvisa.attributes
 import pyvisa.constants
 from pyvisa_sim.sessions import serial
 
 serial.SerialInstrumentSession
 
 
-@pytest.mark.dependency()
+def test_serial_nonsupported_vi_attr(resource_manager):
+    instr = resource_manager.open_resource(
+        "ASRL1::INSTR", read_termination="\n", write_termination="\r\n"
+    )
+    visa_library = instr.visalib
+    session_handle = instr.session
+    session = visa_library.sessions[session_handle]
+
+    old_key = pyvisa.constants.ResourceAttribute.asrl_avalaible_number
+    old_value = pyvisa.attributes.AttributesByID[old_key]
+
+    del pyvisa.attributes.AttributesByID[old_key]
+
+    assert session.get_attribute(
+        pyvisa.constants.ResourceAttribute.asrl_avalaible_number
+    ) == (0, pyvisa.constants.StatusCode.error_nonsupported_attribute)
+
+    pyvisa.attributes.AttributesByID[old_key] = old_value
+
+    old_resources = pyvisa.attributes.AttrVI_ATTR_ASRL_AVAIL_NUM.resources
+    pyvisa.attributes.AttrVI_ATTR_ASRL_AVAIL_NUM.resources = []
+    assert session.get_attribute(
+        pyvisa.constants.ResourceAttribute.asrl_avalaible_number
+    ) == (0, pyvisa.constants.StatusCode.error_nonsupported_attribute)
+    pyvisa.attributes.AttrVI_ATTR_ASRL_AVAIL_NUM.resources = old_resources
+
+    session.device._input_buffer = bytearray()
+    session.device._output_buffers.clear()
+
+
+def test_serial_bytes_in_buffer(resource_manager):
+    instr = resource_manager.open_resource(
+        "ASRL4::INSTR",
+        read_termination="\n",
+        write_termination="\r\n",
+    )
+    visa_library = instr.visalib
+    session_handle = instr.session
+    session = visa_library.sessions[session_handle]
+
+    instr.write("*IDN?")
+    instr.write(":VOLT:IMM:AMPL?")
+    assert instr.bytes_in_buffer == len(f"SCPI,MOCK,VERSION_1.0\n{1.0:+.8E}\n")
+
+    session.device._input_buffer = bytearray()
+    session.device._output_buffers.clear()
+
+
 def test_serial_flush(resource_manager):
     instr = resource_manager.open_resource(
         "ASRL4::INSTR",
         read_termination="\n",
         write_termination="\r\n",
     )
+    visa_library = instr.visalib
+    session_handle = instr.session
+    session = visa_library.sessions[session_handle]
+
     instr.write("*IDN?")
-    assert instr.bytes_in_buffer != 0
+    assert session.device._output_buffers != collections.deque()
 
-    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)
-    assert instr.bytes_in_buffer == 0
+    instr.flush(pyvisa.constants.BufferOperation.discard_receive_buffer)
+    assert session.device._output_buffers == collections.deque()
+
+    session.device._input_buffer = bytearray()
+    session.device._output_buffers.clear()
 
 
-@pytest.mark.dependency(depends=["test_serial_flush"])
 def test_serial_write_with_termination_last_bit(resource_manager):
     instr = resource_manager.open_resource(
         "ASRL4::INSTR",
         read_termination="\n",
         write_termination="\r\n",
     )
+    visa_library = instr.visalib
+    session_handle = instr.session
+    session = visa_library.sessions[session_handle]
+
     # Ensure that we test the `asrl_end` block of serial.SerialInstrumentSession.write
     instr.set_visa_attribute(
         pyvisa.constants.ResourceAttribute.asrl_end_out,
@@ -43,18 +101,5 @@ def test_serial_write_with_termination_last_bit(resource_manager):
     instr.write("*IDN?")
     assert instr.read() == "SCPI,MOCK,VERSION_1.0"
 
-    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)
-
-
-@pytest.mark.dependency(depends=["test_serial_flush"])
-def test_serial_bytes_in_buffer(resource_manager):
-    instr = resource_manager.open_resource(
-        "ASRL4::INSTR",
-        read_termination="\n",
-        write_termination="\r\n",
-    )
-    instr.write("*IDN?")
-    instr.write(":VOLT:IMM:AMPL?")
-    assert instr.bytes_in_buffer == len(f"SCPI,MOCK,VERSION_1.0\n{1.0:+.8E}\n")
-
-    instr.flush(pyvisa.constants.BufferOperation.discard_read_buffer_no_io)
+    session.device._input_buffer = bytearray()
+    session.device._output_buffers.clear()


### PR DESCRIPTION
Made `VI_ATTR_ASRL_AVAIL_NUM` report the number of bytes in the internal receive buffer, not just the default of 0 all the time. Also implemented some of [`viFlush`](https://www.ni.com/docs/en-US/bundle/ni-visa-api-ref/page/ni-visa-api-ref/viflush.html).

All tests pass.

Should fix #93.

Could be a stepping stone for #50 to actually clear the buffers like [`viClear`](https://www.ni.com/docs/en-US/bundle/ni-visa-api-ref/page/ni-visa-api-ref/viclear.html), now that flush is available.

Worked around #82 by calling the new flush function after each test to clear the internal resource manager's buffer after every test. This is why I made the serial tests dependent on the flush buffer test.