### PR TITLE
Add support for raw bytes in dialogues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 PyVISA-sim Changelog
 ====================
 
+Unreleased
+----------
+- add support for BYTES directive PR #220
+  BYTES allows raw bytes to be inserted into dialogues, useful for non-ASCII
+  instruments.
+
 0.7.1 (04-09-2025)
 ------------------
 

--- a/docs/source/definitions.rst
+++ b/docs/source/definitions.rst
@@ -179,7 +179,7 @@ You can also specify the valid values, for example:
 Notice that even if the type is a float, the communication is done with strings.
 
 
-raw bytes in dialogues
+Raw bytes in dialogues
 ----------------------
 
 Sometimes instruments use a non-ASCII communication protocol. PyVISA-sim
@@ -187,24 +187,16 @@ supports inserting raw bytes into dialog query and response definitions for
 this situation.
 
 In a query/response definition, substrings of the form ``BYTES(...)`` are
-replaced with the raw bytes specified inside the parenthesis. The syntax for
-the raw bytes is the same as that accepted by python's ``bytes.fromhex()``
-method; that is to say, the allowed characters are 0–9, a–z, A–Z, and
-whitespace, and there must be an even number of non-whitespace characters.
-
-Here are some examples of how the ``BYTES()`` directive is parsed:
-
-* ``"abcdefg"`` -> ``b"abcdefg"``
-* ``"BYTES()"`` -> ``b"BYTES()"``
-* ``"BYTES(4c)"`` -> ``b"\x4c"``
-* ``"BYTES(01)BYTES(02)"`` -> ``b"\x01\x02"``
-* ``"abBYTES(cd)ef"`` -> ``b"ab\xcdef"``
+replaced with the raw bytes specified inside the parenthesis. The bytes inside
+the directive may be specified using YAML's escaped 8-bit unicode characters
+using the ``\x`` escape sequence. For instance, the byte ``0b10101010`` is
+represented as ``\xaa``. See below for example usage.
 
 .. code-block:: yaml
 
    dialogues:
-     - q: "BYTES(aa 55 00 02 08 01 f4)"
-       r: "BYTES(aa 55 00 02 08 01 f4)"
+     - q: "BYTES(\xaa\x55\x00\x02\x08\x01\xf4)"
+       r: "BYTES(\xaa\x55\x00\x02\x08\x01\xf4)"
 
 randomized output
 -----------------

--- a/docs/source/definitions.rst
+++ b/docs/source/definitions.rst
@@ -179,6 +179,33 @@ You can also specify the valid values, for example:
 Notice that even if the type is a float, the communication is done with strings.
 
 
+raw bytes in dialogues
+----------------------
+
+Sometimes instruments use a non-ASCII communication protocol. PyVISA-sim
+supports inserting raw bytes into dialog query and response definitions for
+this situation.
+
+In a query/response definition, substrings of the form ``BYTES(...)`` are
+replaced with the raw bytes specified inside the parenthesis. The syntax for
+the raw bytes is the same as that accepted by python's ``bytes.fromhex()``
+method; that is to say, the allowed characters are 0–9, a–z, A–Z, and
+whitespace, and there must be an even number of non-whitespace characters.
+
+Here are some examples of how the ``BYTES()`` directive is parsed:
+
+* ``"abcdefg"`` -> ``b"abcdefg"``
+* ``"BYTES()"`` -> ``b"BYTES()"``
+* ``"BYTES(4c)"`` -> ``b"\x4c"``
+* ``"BYTES(01)BYTES(02)"`` -> ``b"\x01\x02"``
+* ``"abBYTES(cd)ef"`` -> ``b"ab\xcdef"``
+
+.. code-block:: yaml
+
+   dialogues:
+     - q: "BYTES(aa 55 00 02 08 01 f4)"
+       r: "BYTES(aa 55 00 02 08 01 f4)"
+
 randomized output
 -----------------
 

--- a/pyvisa_sim/component.py
+++ b/pyvisa_sim/component.py
@@ -80,9 +80,9 @@ def to_bytes(val: Literal[Responses.NO]) -> Literal[Responses.NO]: ...
 def to_bytes(val):
     """Takes a text message or NoResponse and encode it.
 
-    Any substrings of the form "BYTES(...)" with "..." being a valid
-    hexadecimal string in the format expected by bytes.fromhex() will be
-    replaced with the bytes inside the BYTES directive.
+    Any substring of the form "BYTES(...)" where "..." is some substring, that
+    substring is encoded using latin-1 rather than utf-8 and the surrounding
+    BYTES() directive is removed.
 
     Examples
     --------

--- a/pyvisa_sim/component.py
+++ b/pyvisa_sim/component.py
@@ -45,24 +45,27 @@ OptionalBytes: TypeAlias = Union[bytes, Literal[Responses.NO]]
 def _single_to_bytes(val: str) -> bytes:
     """Encodes a string with UTF-8, handling a single BYTES(...) directive.
 
-    If the string is "BYTES(...)" where "..." is a valid hexadecimal string in
-    the format expected by bytes.fromhex(), encoding is skipped and the raw
-    bytes inside the BYTES directive are returned instead.
+    If the string is "BYTES(...)" where "..." is some substring, that substring
+    is encoded using latin-1 rather than utf-8 and the surrounding BYTES()
+    directive is removed.
 
     Examples
     --------
 
     The string "abcdefg" will be encoded to b"abcdefg".
 
-    The string "BYTES(014e80)" will be encoded to b"\x01\x4e\x80".
+    The string "BYTES(\x01\x02\x03\xf0\xe0\xc0)" will be encoded to
+    b"\x10\x20\x30\xf0\xe0\xc0".
 
-    The string "abBYTES(014e80)cd" will be encoded to b"abBYTES(014e80)cd".
+    The string "abBYTES(\x01\x02\x03\xf0\xe0\xc0)cd" will be encoded to
+    b"abBYTES(\x01\x02\x03\xf0\xe0\xc0)cd".
 
-    The string "BYTES(01)BYTES(02)" will be encoded to b"BYTES(01)BYTES(02)".
+    The string "BYTES(\x01)BYTES(\x02)" will be encoded to
+    b"BYTES(\x01)BYTES(\x02)".
 
     """
-    if match := re.fullmatch(r"BYTES\(([a-fA-f0-9 ]+)\)", val):
-        return bytes.fromhex(match[1])
+    if match := re.fullmatch(r"BYTES\((.*)\)", val):
+        return match[1].encode("latin-1")
     return val.encode()
 
 
@@ -98,7 +101,7 @@ def to_bytes(val):
 
     val = val.replace("\\r", "\r").replace("\\n", "\n")
 
-    partitioned_string = re.split(r"(BYTES\([a-fA-F0-9 ]+\))", val)
+    partitioned_string = re.split(r"(BYTES\([^)]+\))", val)
     return b"".join(map(_single_to_bytes, partitioned_string))
 
 

--- a/pyvisa_sim/component.py
+++ b/pyvisa_sim/component.py
@@ -42,6 +42,30 @@ OptionalStr: TypeAlias = Union[str, Literal[Responses.NO]]
 OptionalBytes: TypeAlias = Union[bytes, Literal[Responses.NO]]
 
 
+def _single_to_bytes(val: str) -> bytes:
+    """Encodes a string with UTF-8, handling a single BYTES(...) directive.
+
+    If the string is "BYTES(...)" where "..." is a valid hexadecimal string in
+    the format expected by bytes.fromhex(), encoding is skipped and the raw
+    bytes inside the BYTES directive are returned instead.
+
+    Examples
+    --------
+
+    The string "abcdefg" will be encoded to b"abcdefg".
+
+    The string "BYTES(014e80)" will be encoded to b"\x01\x4e\x80".
+
+    The string "abBYTES(014e80)cd" will be encoded to b"abBYTES(014e80)cd".
+
+    The string "BYTES(01)BYTES(02)" will be encoded to b"BYTES(01)BYTES(02)".
+
+    """
+    if match := re.fullmatch(r"BYTES\(([a-fA-f0-9 ]+)\)", val):
+        return bytes.fromhex(match[1])
+    return val.encode()
+
+
 @overload
 def to_bytes(val: str) -> bytes: ...
 
@@ -51,12 +75,31 @@ def to_bytes(val: Literal[Responses.NO]) -> Literal[Responses.NO]: ...
 
 
 def to_bytes(val):
-    """Takes a text message or NoResponse and encode it."""
+    """Takes a text message or NoResponse and encode it.
+
+    Any substrings of the form "BYTES(...)" with "..." being a valid
+    hexadecimal string in the format expected by bytes.fromhex() will be
+    replaced with the bytes inside the BYTES directive.
+
+    Examples
+    --------
+
+    The string "abcdefg" will be encoded to b"abcdefg".
+
+    The string "BYTES(014e80)" will be encoded to b"\x01\x4e\x80".
+
+    The string "abBYTES(014e80)cd" will be encoded to b"ab\x01\x4e\x80cd".
+
+    The string "BYTES(01)BYTES(02)" will be encoded to b"\x01\x02".
+
+    """
     if val is NoResponse:
         return val
 
     val = val.replace("\\r", "\r").replace("\\n", "\n")
-    return val.encode()
+
+    partitioned_string = re.split(r"(BYTES\([a-fA-F0-9 ]+\))", val)
+    return b"".join(map(_single_to_bytes, partitioned_string))
 
 
 T = TypeVar("T", int, float, str)

--- a/pyvisa_sim/testsuite/test_component.py
+++ b/pyvisa_sim/testsuite/test_component.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pyvisa_sim import component
+
+
+@pytest.mark.parametrize(
+    "data, want",
+    [
+        ("abcdefg", b"abcdefg"),
+        ("BYTES()", b"BYTES()"),
+        ("BYTES(4c)", b"\x4c"),
+        ("BYTES(01)BYTES(02)", b"\x01\x02"),
+        ("abBYTES(cd)ef", b"ab\xcdef"),
+    ],
+)
+def test_bytes_directive(data: str, want: str):
+    got = component.to_bytes(data)
+    assert got == want

--- a/pyvisa_sim/testsuite/test_component.py
+++ b/pyvisa_sim/testsuite/test_component.py
@@ -7,10 +7,14 @@ from pyvisa_sim import component
     "data, want",
     [
         ("abcdefg", b"abcdefg"),
-        ("BYTES()", b"BYTES()"),
-        ("BYTES(4c)", b"\x4c"),
-        ("BYTES(01)BYTES(02)", b"\x01\x02"),
-        ("abBYTES(cd)ef", b"ab\xcdef"),
+        ("BYTES()", b""),
+        ("BYTES())", b")"),
+        # "\x29" == ")"
+        ("BYTES(\x29\x29)", b"\x29\x29"),
+        ("BYTES(\x01)BYTES(\x02)", b"\x01\x02"),
+        ("BYTES(\x01\x02\x03\xf0\xe0\xc0)", b"\x01\x02\x03\xf0\xe0\xc0"),
+        ("abBYTES(\x01\x02\x03\xf0\xe0\xc0)cd", b"ab\x01\x02\x03\xf0\xe0\xc0cd"),
+        ("BYTES(\xaa\x55\x00\x02\x08\x01\xf4)", b"\xaa\x55\x00\x02\x08\x01\xf4"),
     ],
 )
 def test_bytes_directive(data: str, want: str):


### PR DESCRIPTION
I needed to simulate an instrument that uses bytes in general for messages rather than being restricted to printable bytes only. I tried using string hex escape codes (e.g. `"\x01\x02\x03"`) in dialogue definitions in the yaml file, but an intermediate parsing function `component.to_bytes()` does not keep them intact every time; for example, `"\xaa\x55\x00\x02\x08\x01\xf4".encode()` gives `\xc2\xaa\x55\x00\x02\x08\x01\xc3\xb4`.

This patch extends `component.to_bytes()` with a new directive, `BYTES()`, that marks the content inside as raw hex bytes to be preserved in the conversion to bytes.